### PR TITLE
fix: Add Docker Desktop version requirement / troubleshooting note [#2]

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,0 @@
-# Implementation Plan for #2
-
-- [x] Add a Docker Desktop version requirement note to the Prerequisites section clarifying that Docker Desktop must include `docker sandbox` support (available in Docker Desktop 4.40+)
-- [x] Add a verification step to the Quick Start section recommending users run `docker sandbox ls` before first use to confirm sandbox support is available
-- [x] Add troubleshooting entries for "Docker sandbox state is stale" (restart Docker Desktop or run `docker sandbox rm mog && mog init`) and "docker: 'sandbox' is not a docker command" (update Docker Desktop to a version that supports `docker sandbox`)


### PR DESCRIPTION
## Summary

Closes #2

### What was done

Done. Added two troubleshooting entries to the README:

- **"Docker sandbox state is stale"** — advises restarting Docker Desktop or removing/recreating the sandbox
- **"docker: 'sandbox' is not a docker command"** — advises updating Docker Desktop to 4.40+

The implementation plan is now fully checked off.

This PR was generated by [mog](https://github.com/bobbyg603/mog) using Claude Code in a Docker sandbox.

### Issue: Add Docker Desktop version requirement / troubleshooting note

It may be helpful to add a short note in the README that mog depends on Docker Desktop having Docker Sandbox support available. On macOS and Windows, users may run into errors like “Docker sandbox state is stale” or “docker: 'sandbox' is not a docker command” if Docker Desktop is outdated or missing sandbox support. A brief troubleshooting section could mention that users should make sure Docker Desktop is installed, running, and updated to a version that includes docker sandbox, then verify it by running docker sandbox ls before using mog.

---
*Please review the changes carefully before merging.*