### PR TITLE
feat: support including files/directories and .moginclude file

### DIFF
--- a/src/include.test.ts
+++ b/src/include.test.ts
@@ -1,0 +1,245 @@
+import { describe, test, expect } from "bun:test";
+import { parseMogIncludeFile, copyIncludeFiles, cleanupIncludeFiles } from "./include";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "mog-test-"));
+}
+
+describe("parseMogIncludeFile", () => {
+  test("returns empty array when .moginclude does not exist", () => {
+    const tmpDir = createTmpDir();
+    expect(parseMogIncludeFile(tmpDir)).toEqual([]);
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  test("parses paths from .moginclude file", () => {
+    const tmpDir = createTmpDir();
+    fs.writeFileSync(path.join(tmpDir, ".moginclude"), ".env\nconfig/local/\n");
+
+    const result = parseMogIncludeFile(tmpDir);
+    expect(result).toEqual([
+      path.resolve(tmpDir, ".env"),
+      path.resolve(tmpDir, "config/local/"),
+    ]);
+
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  test("ignores comments and blank lines", () => {
+    const tmpDir = createTmpDir();
+    fs.writeFileSync(
+      path.join(tmpDir, ".moginclude"),
+      "# This is a comment\n\n.env\n\n# Another comment\ndata/\n"
+    );
+
+    const result = parseMogIncludeFile(tmpDir);
+    expect(result).toEqual([
+      path.resolve(tmpDir, ".env"),
+      path.resolve(tmpDir, "data/"),
+    ]);
+
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  test("trims whitespace from lines", () => {
+    const tmpDir = createTmpDir();
+    fs.writeFileSync(path.join(tmpDir, ".moginclude"), "  .env  \n  config/  \n");
+
+    const result = parseMogIncludeFile(tmpDir);
+    expect(result).toEqual([
+      path.resolve(tmpDir, ".env"),
+      path.resolve(tmpDir, "config/"),
+    ]);
+
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  test("returns empty array for empty file", () => {
+    const tmpDir = createTmpDir();
+    fs.writeFileSync(path.join(tmpDir, ".moginclude"), "");
+
+    expect(parseMogIncludeFile(tmpDir)).toEqual([]);
+
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  test("returns empty array for file with only comments and blanks", () => {
+    const tmpDir = createTmpDir();
+    fs.writeFileSync(path.join(tmpDir, ".moginclude"), "# comment\n\n# another\n");
+
+    expect(parseMogIncludeFile(tmpDir)).toEqual([]);
+
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+});
+
+describe("copyIncludeFiles", () => {
+  test("copies a single file preserving relative path", () => {
+    const repoRoot = createTmpDir();
+    const worktreeDir = createTmpDir();
+
+    const srcFile = path.join(repoRoot, ".env");
+    fs.writeFileSync(srcFile, "SECRET=abc");
+
+    const copied = copyIncludeFiles([srcFile], repoRoot, worktreeDir);
+
+    expect(copied).toEqual([path.join(worktreeDir, ".env")]);
+    expect(fs.readFileSync(path.join(worktreeDir, ".env"), "utf-8")).toBe("SECRET=abc");
+
+    fs.rmSync(repoRoot, { recursive: true });
+    fs.rmSync(worktreeDir, { recursive: true });
+  });
+
+  test("copies a file in a nested directory preserving relative path", () => {
+    const repoRoot = createTmpDir();
+    const worktreeDir = createTmpDir();
+
+    const nestedDir = path.join(repoRoot, "config", "local");
+    fs.mkdirSync(nestedDir, { recursive: true });
+    const srcFile = path.join(nestedDir, "settings.json");
+    fs.writeFileSync(srcFile, '{"key": "value"}');
+
+    const copied = copyIncludeFiles([srcFile], repoRoot, worktreeDir);
+
+    expect(copied).toEqual([path.join(worktreeDir, "config", "local", "settings.json")]);
+    expect(fs.readFileSync(copied[0]!, "utf-8")).toBe('{"key": "value"}');
+
+    fs.rmSync(repoRoot, { recursive: true });
+    fs.rmSync(worktreeDir, { recursive: true });
+  });
+
+  test("copies a directory recursively", () => {
+    const repoRoot = createTmpDir();
+    const worktreeDir = createTmpDir();
+
+    const srcDir = path.join(repoRoot, "config", "local");
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(srcDir, "a.txt"), "aaa");
+    fs.writeFileSync(path.join(srcDir, "b.txt"), "bbb");
+
+    const copied = copyIncludeFiles([srcDir], repoRoot, worktreeDir);
+
+    expect(copied).toEqual([path.join(worktreeDir, "config", "local")]);
+    expect(fs.readFileSync(path.join(worktreeDir, "config", "local", "a.txt"), "utf-8")).toBe("aaa");
+    expect(fs.readFileSync(path.join(worktreeDir, "config", "local", "b.txt"), "utf-8")).toBe("bbb");
+
+    fs.rmSync(repoRoot, { recursive: true });
+    fs.rmSync(worktreeDir, { recursive: true });
+  });
+
+  test("copies multiple files and directories", () => {
+    const repoRoot = createTmpDir();
+    const worktreeDir = createTmpDir();
+
+    // Create a file
+    fs.writeFileSync(path.join(repoRoot, ".env"), "SECRET=123");
+
+    // Create a directory with contents
+    const dir = path.join(repoRoot, "fixtures");
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, "data.json"), '{"x":1}');
+
+    const copied = copyIncludeFiles(
+      [path.join(repoRoot, ".env"), dir],
+      repoRoot,
+      worktreeDir
+    );
+
+    expect(copied).toHaveLength(2);
+    expect(fs.existsSync(path.join(worktreeDir, ".env"))).toBe(true);
+    expect(fs.existsSync(path.join(worktreeDir, "fixtures", "data.json"))).toBe(true);
+
+    fs.rmSync(repoRoot, { recursive: true });
+    fs.rmSync(worktreeDir, { recursive: true });
+  });
+
+  test("copies a nested directory when parent does not exist in worktree", () => {
+    const repoRoot = createTmpDir();
+    const worktreeDir = createTmpDir();
+
+    const srcDir = path.join(repoRoot, "config", "local");
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(srcDir, "a.txt"), "aaa");
+
+    // worktreeDir/config/ does not exist — copyIncludeFiles must create it
+    const copied = copyIncludeFiles([srcDir], repoRoot, worktreeDir);
+
+    expect(copied).toEqual([path.join(worktreeDir, "config", "local")]);
+    expect(fs.readFileSync(path.join(worktreeDir, "config", "local", "a.txt"), "utf-8")).toBe("aaa");
+
+    fs.rmSync(repoRoot, { recursive: true });
+    fs.rmSync(worktreeDir, { recursive: true });
+  });
+
+  test("returns empty array when no files to copy", () => {
+    const repoRoot = createTmpDir();
+    const worktreeDir = createTmpDir();
+
+    const copied = copyIncludeFiles([], repoRoot, worktreeDir);
+    expect(copied).toEqual([]);
+
+    fs.rmSync(repoRoot, { recursive: true });
+    fs.rmSync(worktreeDir, { recursive: true });
+  });
+});
+
+describe("cleanupIncludeFiles", () => {
+  test("unstages a copied file but leaves it on disk", () => {
+    const worktreeDir = createTmpDir();
+    const filePath = path.join(worktreeDir, ".env");
+    fs.writeFileSync(filePath, "SECRET=abc");
+
+    cleanupIncludeFiles([filePath], worktreeDir);
+
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.readFileSync(filePath, "utf-8")).toBe("SECRET=abc");
+
+    fs.rmSync(worktreeDir, { recursive: true });
+  });
+
+  test("unstages a copied directory but leaves it on disk", () => {
+    const worktreeDir = createTmpDir();
+    const dirPath = path.join(worktreeDir, "config", "local");
+    fs.mkdirSync(dirPath, { recursive: true });
+    fs.writeFileSync(path.join(dirPath, "a.txt"), "aaa");
+
+    cleanupIncludeFiles([dirPath], worktreeDir);
+
+    expect(fs.existsSync(dirPath)).toBe(true);
+    expect(fs.readFileSync(path.join(dirPath, "a.txt"), "utf-8")).toBe("aaa");
+
+    fs.rmSync(worktreeDir, { recursive: true });
+  });
+
+  test("handles already-removed files gracefully", () => {
+    const worktreeDir = createTmpDir();
+    const filePath = path.join(worktreeDir, "gone.txt");
+
+    // Should not throw
+    cleanupIncludeFiles([filePath], worktreeDir);
+
+    fs.rmSync(worktreeDir, { recursive: true });
+  });
+
+  test("unstages multiple files and directories but leaves them on disk", () => {
+    const worktreeDir = createTmpDir();
+
+    const file = path.join(worktreeDir, ".env");
+    fs.writeFileSync(file, "data");
+
+    const dir = path.join(worktreeDir, "fixtures");
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, "x.txt"), "x");
+
+    cleanupIncludeFiles([file, dir], worktreeDir);
+
+    expect(fs.existsSync(file)).toBe(true);
+    expect(fs.existsSync(dir)).toBe(true);
+    expect(fs.readFileSync(path.join(dir, "x.txt"), "utf-8")).toBe("x");
+
+    fs.rmSync(worktreeDir, { recursive: true });
+  });
+});

--- a/src/include.ts
+++ b/src/include.ts
@@ -1,0 +1,47 @@
+import fs from "fs";
+import path from "path";
+
+export function parseMogIncludeFile(repoRoot: string): string[] {
+  const mogIncludePath = path.join(repoRoot, ".moginclude");
+
+  if (!fs.existsSync(mogIncludePath)) {
+    return [];
+  }
+
+  const content = fs.readFileSync(mogIncludePath, "utf-8");
+  return content
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line !== "" && !line.startsWith("#"))
+    .map(line => path.resolve(repoRoot, line));
+}
+
+export function copyIncludeFiles(includeFiles: string[], repoRoot: string, worktreeDir: string): string[] {
+  const copiedFiles: string[] = [];
+  for (const filePath of includeFiles) {
+    const relativePath = path.relative(repoRoot, filePath);
+    const dest = path.join(worktreeDir, relativePath);
+    const isDir = fs.statSync(filePath).isDirectory();
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    if (isDir) {
+      fs.cpSync(filePath, dest, { recursive: true });
+    } else {
+      fs.copyFileSync(filePath, dest);
+    }
+    copiedFiles.push(dest);
+  }
+  return copiedFiles;
+}
+
+export function cleanupIncludeFiles(copiedFiles: string[], worktreeDir: string): void {
+  for (const filePath of copiedFiles) {
+    try {
+      const isDir = fs.statSync(filePath).isDirectory();
+      const relativePath = path.relative(worktreeDir, filePath);
+      const gitRmArgs = ["git", "rm", "--cached", "--ignore-unmatch", ...(isDir ? ["-r"] : []), relativePath];
+      Bun.spawnSync(gitRmArgs, { cwd: worktreeDir });
+    } catch {
+      // File/directory may already be gone
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { loadConfig, saveConfig, loadRepoConfig, saveRepoConfig } from "./config
 import type { MogConfig } from "./config";
 import type { PRFeedback } from "./github";
 import { log } from "./log";
+import { parseMogIncludeFile, copyIncludeFiles, cleanupIncludeFiles } from "./include";
 
 const SANDBOX_NAME = "mog";
 const TEMPLATE_TAG = "mog-template:latest";
@@ -77,7 +78,7 @@ function printUsage(): void {
   console.log("Example:");
   console.log("  mog init");
   console.log("  mog 123");
-  console.log("  mog 123 --include .env");
+  console.log("  mog 123 --include .env --include config/local/");
   console.log("  mog workingdevshero/automate-it 123");
   console.log("  mog list");
   console.log("  mog list --verbose");
@@ -201,21 +202,30 @@ async function main() {
   }
 
   // Parse --include and --fresh flags
-  const includeFiles: string[] = [];
+  const cliIncludePaths: string[] = [];
   const filteredArgs: string[] = [];
   let fresh = false;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--include" && i + 1 < args.length) {
-      const filePath = path.resolve(args[i + 1]!);
-      if (!fs.existsSync(filePath)) {
-        log.die(`Include file not found: ${args[i + 1]}`);
-      }
-      includeFiles.push(filePath);
+      cliIncludePaths.push(path.resolve(args[i + 1]!));
       i++; // skip the path argument
     } else if (args[i] === "--fresh") {
       fresh = true;
     } else {
       filteredArgs.push(args[i]!);
+    }
+  }
+
+  // Resolve repo root once for .moginclude parsing and later for copying
+  const repoRootResult = Bun.spawnSync(["git", "rev-parse", "--show-toplevel"]);
+  const repoRoot = repoRootResult.exitCode === 0 ? repoRootResult.stdout.toString().trim() : "";
+
+  // Merge .moginclude paths with --include CLI args, deduplicate, and validate
+  const mogIncludePaths = repoRoot ? parseMogIncludeFile(repoRoot) : [];
+  const includeFiles = [...new Set([...mogIncludePaths, ...cliIncludePaths])];
+  for (const filePath of includeFiles) {
+    if (!fs.existsSync(filePath)) {
+      log.die(`Include path not found: ${filePath}`);
     }
   }
 
@@ -289,14 +299,10 @@ async function main() {
     log.ok(`Found existing PR #${pr.prNumber} — will include review feedback and update it.`);
   }
 
-  // Copy included files into worktree
-  const copiedFiles: string[] = [];
-  for (const filePath of includeFiles) {
-    const basename = path.basename(filePath);
-    const dest = path.join(worktreeDir, basename);
-    fs.copyFileSync(filePath, dest);
-    copiedFiles.push(dest);
-    log.ok(`Included: ${basename}`);
+  // Copy included files/directories into worktree
+  const copiedFiles = copyIncludeFiles(includeFiles, repoRoot, worktreeDir);
+  for (const filePath of copiedFiles) {
+    log.ok(`Included: ${path.relative(worktreeDir, filePath)}`);
   }
 
   // Build prompts
@@ -318,16 +324,8 @@ async function main() {
 
   const summary = await runClaude(SANDBOX_NAME, worktreeDir, defaultBranch, planningPrompt, buildingPromptFn, reviewPrompt, summaryPrompt);
 
-  // Remove included files so they don't end up in the PR
-  for (const filePath of copiedFiles) {
-    try {
-      fs.unlinkSync(filePath);
-      // Unstage if Claude happened to git add it
-      Bun.spawnSync(["git", "rm", "--cached", "--ignore-unmatch", path.basename(filePath)], { cwd: worktreeDir });
-    } catch {
-      // File may already be gone
-    }
-  }
+  // Remove included files/directories so they don't end up in the PR
+  cleanupIncludeFiles(copiedFiles, worktreeDir);
 
   // Push and create/update PR
   pushAndCreatePR(repo, worktreeDir, branchName, defaultBranch, issueNum, issue, summary, existingPR);
@@ -344,8 +342,13 @@ function printUsage(): void {
   console.log("  mog <owner/repo> list [--verbose] — list open issues for a repo");
   console.log();
   console.log("Options:");
-  console.log("  --include <file>              — copy a file into the worktree (repeatable)");
+  console.log("  --include <path>              — copy a file or directory into the worktree (repeatable)");
   console.log("  --fresh                       — ignore existing PR, start a brand new one");
+  console.log("  --version, -v                 — print the current version");
+  console.log();
+  console.log("Auto-include:");
+  console.log("  Add a .moginclude file to the repo root to always copy specific paths.");
+  console.log("  One path per line, comments (#) and blank lines are ignored.");
   console.log();
   console.log("Config keys: user.name, user.email");
   console.log("  Git identity is auto-detected from your repo's git config.");
@@ -356,7 +359,7 @@ function printUsage(): void {
   console.log("  mog config user.name \"Your Name\"");
   console.log("  mog config --global user.email \"you@example.com\"");
   console.log("  mog 123");
-  console.log("  mog 123 --include .env");
+  console.log("  mog 123 --include .env --include config/local/");
   console.log("  mog workingdevshero/automate-it 123");
   console.log("  mog list");
   console.log("  mog list --verbose");


### PR DESCRIPTION
## Summary
- Add support for including **directories** (not just files) via `--include`, preserving relative paths in the worktree
- Add `.moginclude` file support — a repo-root config file that automatically includes specified paths on every run, so you don't have to pass `--include` repeatedly
- Included files/directories are now **kept on disk** in the worktree after cleanup (only unstaged from git), so Claude can reference them during the task without them leaking into the PR
- Comments (`#`) and blank lines are supported in `.moginclude`